### PR TITLE
Update standards contributions for Keycloak 26 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ FAPI related accomplishments by FAPI-SIG and OAuth SIG, other contributors and k
 
   - [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
 
+#### Keycloak 26
+
+  - [Initiating User Registration via OpenID Connect 1.0](https://openid.net/specs/openid-connect-prompt-create-1_0.html)
+
 #### In progress
 
 ##### OpenID for Verifiable Credentials


### PR DESCRIPTION
Add link to [Initiating User Registration via OpenID Connect](https://openid.net/specs/openid-connect-prompt-create-1_0.html) added in Keycloak 26.1.x

See: https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-endpoint-for-initiate-registration-from-oidc-client

https://github.com/keycloak/keycloak/pull/35903