### PR TITLE
[OID4VCI] Add opt-in sample mDoc credential

### DIFF
--- a/oid4vci-deployment/Readme.md
+++ b/oid4vci-deployment/Readme.md
@@ -85,6 +85,8 @@ Our config contains many settings to configure Keycloak. The more relevant are:
 
 The sample is excluded from `credentials.enabled` by default because mDoc support is not in Keycloak 26.7.x. Use a Keycloak main/nightly build that contains the experimental `oid4vc-mdoc` feature. Enabling the sample automatically adds that feature to `KEYCLOAK_FEATURES`.
 
+Re-running `keycloak-ssi config` reconciles the managed credential scopes and their assignments on existing clients. Disabled scopes are removed so they are no longer advertised, and all enabled credentials are automatically granted to the demo user `francis`.
+
 This is an issuance/interoperability sample, not a complete ISO/IEC 18013-5 mDL profile. A production mDL must also supply the remaining mandatory data elements with their required CBOR types, including tagged dates, portrait bytes, and structured driving privileges, and must use a production document-signer certificate and trust chain.
 
 ### Run and test with Keycloak nightly
@@ -111,26 +113,7 @@ Recreate and configure the deployment so the changed feature list is applied at 
 ./keycloak-ssi.sh config
 ```
 
-Keycloak 26.7+ requires an explicit per-user grant. Grant the `MobileDrivingLicence` credential to `francis` in the Admin Console, or use the Admin REST API:
-
-```bash
-ADMIN_TOKEN=$(curl -sk \
-  -d client_id=admin-cli \
-  -d username=admin \
-  -d password=admin \
-  -d grant_type=password \
-  https://localhost:8443/realms/master/protocol/openid-connect/token | jq -r .access_token)
-
-USER_ID=$(curl -sk \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  'https://localhost:8443/admin/realms/oid4vc-vci/users?username=francis&exact=true' | jq -r '.[0].id')
-
-curl -ski -X POST \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{"credentialScopeName":"MobileDrivingLicence"}' \
-  "https://localhost:8443/admin/realms/oid4vc-vci/users/$USER_ID/vc/credentials"
-```
+Keycloak 26.7+ requires an explicit per-user grant. The `config` command grants every credential selected in `credentials.enabled`, including `MobileDrivingLicence`, to the demo user `francis` automatically.
 
 Verify discovery and issue the credential:
 

--- a/oid4vci-deployment/Readme.md
+++ b/oid4vci-deployment/Readme.md
@@ -6,7 +6,7 @@ Bring OpenID for Verifiable Credential Issuance (OID4VCI) to a vanilla Keycloak 
 
 - Opinionated Keycloak instance (Postgres + HTTPS) with the `oid4vc-vci` feature enabled.
 - `keycloak-ssi` CLI that wraps every script under `src/` and handles configuration, setup, and testing.
-- Ready-made credential definitions (IdentityCredential, SteuerberaterCredential, KMACredential), an opt-in mDoc sample, and a demo user for both pre-authorized and authorization-code flows.
+- Ready-made credential definitions (IdentityCredential, SteuerberaterCredential, KMACredential, MobileDrivingLicence), selected through `credentials.enabled`, and a demo user for both pre-authorized and authorization-code flows.
 
 ## TL;DR
 
@@ -74,59 +74,6 @@ Our config contains many settings to configure Keycloak. The more relevant are:
 - `database.*`: container DB parameters such as port, username, password.
 - `users.*`: Users that will be added to keycloak.
 - `credentials.enabled`: comma-separated credential client scopes to configure. The default contains the three release-compatible SD-JWT credentials and excludes the experimental mDoc sample.
-
-## Experimental mDoc Sample
-
-`MobileDrivingLicence` demonstrates an `mso_mdoc` credential using:
-
-- DocType `org.iso.18013.5.1.mDL` and namespace `org.iso.18013.5.1`.
-- `ES256` issuer signing, `cose_key` holder binding, and JWT proof of possession.
-- The demo user's `firstName` and `lastName` as `given_name` and `family_name`, plus the static specimen document number `D1234567`.
-
-The sample is excluded from `credentials.enabled` by default because mDoc support is not in Keycloak 26.7.x. Use a Keycloak main/nightly build that contains the experimental `oid4vc-mdoc` feature. Enabling the sample automatically adds that feature to `KEYCLOAK_FEATURES`.
-
-Re-running `keycloak-ssi config` reconciles the managed credential scopes and their assignments on existing clients. Disabled scopes are removed so they are no longer advertised, and all enabled credentials are automatically granted to the demo user `francis`.
-
-This is an issuance/interoperability sample, not a complete ISO/IEC 18013-5 mDL profile. A production mDL must also supply the remaining mandatory data elements with their required CBOR types, including tagged dates, portrait bytes, and structured driving privileges, and must use a production document-signer certificate and trust chain.
-
-### Run and test with Keycloak nightly
-
-Create `config.override.yaml` next to `config.yaml`:
-
-```yaml
-keycloak:
-  enable_preauth_code: true
-  enable_credential_offer_create: true
-  enable_rest_credential_offer: true
-
-keycloak_image:
-  tag: "nightly"
-
-credentials:
-  enabled: "IdentityCredential,SteuerberaterCredential,KMACredential,MobileDrivingLicence"
-```
-
-Recreate and configure the deployment so the changed feature list is applied at server startup:
-
-```bash
-./keycloak-ssi.sh compose up -d --force-recreate
-./keycloak-ssi.sh config
-```
-
-Keycloak 26.7+ requires an explicit per-user grant. The `config` command grants every credential selected in `credentials.enabled`, including `MobileDrivingLicence`, to the demo user `francis` automatically.
-
-Verify discovery and issue the credential:
-
-```bash
-curl -sk \
-  https://localhost:8443/.well-known/openid-credential-issuer/realms/oid4vc-vci \
-  | jq '.credential_configurations_supported.MobileDrivingLicence'
-
-./keycloak-ssi.sh test preauth MobileDrivingLicence
-./keycloak-ssi.sh test authcode MobileDrivingLicence
-```
-
-The discovery entry should report `format: "mso_mdoc"`, DocType `org.iso.18013.5.1.mDL`, `cose_key` binding, and ES256 (COSE algorithm `-7`). The issuance response contains the base64url-encoded CBOR `IssuerSigned` document in its `credential` value.
 
 ## Credential Request Playbooks
 

--- a/oid4vci-deployment/Readme.md
+++ b/oid4vci-deployment/Readme.md
@@ -6,7 +6,7 @@ Bring OpenID for Verifiable Credential Issuance (OID4VCI) to a vanilla Keycloak 
 
 - Opinionated Keycloak instance (Postgres + HTTPS) with the `oid4vc-vci` feature enabled.
 - `keycloak-ssi` CLI that wraps every script under `src/` and handles configuration, setup, and testing.
-- Ready-made credential definitions (IdentityCredential, SteuerberaterCredential, KMACredential) and a demo user for both pre-authorized and authorization-code flows.
+- Ready-made credential definitions (IdentityCredential, SteuerberaterCredential, KMACredential), an opt-in mDoc sample, and a demo user for both pre-authorized and authorization-code flows.
 
 ## TL;DR
 
@@ -73,6 +73,77 @@ Our config contains many settings to configure Keycloak. The more relevant are:
 - `keycloak.https_port`, `keycloak.hostname`: align with your local HTTPS requirements.
 - `database.*`: container DB parameters such as port, username, password.
 - `users.*`: Users that will be added to keycloak.
+- `credentials.enabled`: comma-separated credential client scopes to configure. The default contains the three release-compatible SD-JWT credentials and excludes the experimental mDoc sample.
+
+## Experimental mDoc Sample
+
+`MobileDrivingLicence` demonstrates an `mso_mdoc` credential using:
+
+- DocType `org.iso.18013.5.1.mDL` and namespace `org.iso.18013.5.1`.
+- `ES256` issuer signing, `cose_key` holder binding, and JWT proof of possession.
+- The demo user's `firstName` and `lastName` as `given_name` and `family_name`, plus the static specimen document number `D1234567`.
+
+The sample is excluded from `credentials.enabled` by default because mDoc support is not in Keycloak 26.7.x. Use a Keycloak main/nightly build that contains the experimental `oid4vc-mdoc` feature. Enabling the sample automatically adds that feature to `KEYCLOAK_FEATURES`.
+
+This is an issuance/interoperability sample, not a complete ISO/IEC 18013-5 mDL profile. A production mDL must also supply the remaining mandatory data elements with their required CBOR types, including tagged dates, portrait bytes, and structured driving privileges, and must use a production document-signer certificate and trust chain.
+
+### Run and test with Keycloak nightly
+
+Create `config.override.yaml` next to `config.yaml`:
+
+```yaml
+keycloak:
+  enable_preauth_code: true
+  enable_credential_offer_create: true
+  enable_rest_credential_offer: true
+
+keycloak_image:
+  tag: "nightly"
+
+credentials:
+  enabled: "IdentityCredential,SteuerberaterCredential,KMACredential,MobileDrivingLicence"
+```
+
+Recreate and configure the deployment so the changed feature list is applied at server startup:
+
+```bash
+./keycloak-ssi.sh compose up -d --force-recreate
+./keycloak-ssi.sh config
+```
+
+Keycloak 26.7+ requires an explicit per-user grant. Grant the `MobileDrivingLicence` credential to `francis` in the Admin Console, or use the Admin REST API:
+
+```bash
+ADMIN_TOKEN=$(curl -sk \
+  -d client_id=admin-cli \
+  -d username=admin \
+  -d password=admin \
+  -d grant_type=password \
+  https://localhost:8443/realms/master/protocol/openid-connect/token | jq -r .access_token)
+
+USER_ID=$(curl -sk \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  'https://localhost:8443/admin/realms/oid4vc-vci/users?username=francis&exact=true' | jq -r '.[0].id')
+
+curl -ski -X POST \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"credentialScopeName":"MobileDrivingLicence"}' \
+  "https://localhost:8443/admin/realms/oid4vc-vci/users/$USER_ID/vc/credentials"
+```
+
+Verify discovery and issue the credential:
+
+```bash
+curl -sk \
+  https://localhost:8443/.well-known/openid-credential-issuer/realms/oid4vc-vci \
+  | jq '.credential_configurations_supported.MobileDrivingLicence'
+
+./keycloak-ssi.sh test preauth MobileDrivingLicence
+./keycloak-ssi.sh test authcode MobileDrivingLicence
+```
+
+The discovery entry should report `format: "mso_mdoc"`, DocType `org.iso.18013.5.1.mDL`, `cose_key` binding, and ES256 (COSE algorithm `-7`). The issuance response contains the base64url-encoded CBOR `IssuerSigned` document in its `credential` value.
 
 ## Credential Request Playbooks
 

--- a/oid4vci-deployment/config.override.example.yaml
+++ b/oid4vci-deployment/config.override.example.yaml
@@ -13,3 +13,7 @@
 # database:
 #   password: "${PROD_DB_PASSWORD}"
 #   username: "${PROD_DB_USER}"
+
+# Example: Enable the experimental mDoc sample on a Keycloak main/nightly build
+# credentials:
+#   enabled: "IdentityCredential,SteuerberaterCredential,KMACredential,MobileDrivingLicence"

--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -94,6 +94,15 @@ clients:
   test_client: "http://localhost:4200"
 
 # -----------------------------------------------------------------------------
+# Credential configuration
+# -----------------------------------------------------------------------------
+credentials:
+  # Comma-separated client-scope names from src/config/client-scope-config.json.
+  # MobileDrivingLicence is intentionally excluded because mDoc support requires
+  # a Keycloak main/nightly build with the experimental oid4vc-mdoc feature.
+  enabled: "IdentityCredential,SteuerberaterCredential,KMACredential"
+
+# -----------------------------------------------------------------------------
 # Endpoints configuration
 # -----------------------------------------------------------------------------
 keycloak_endpoints:

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -13,8 +13,8 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
 3. **Enable REST credential-offer creation**  
    Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
-4. **Grant verifiable credentials to the demo user** 
-   On 26.7+, issuance requires an explicit per-user VC grant for each credential scope (IdentityCredential, SteuerberaterCredential, KMACredential). Grant these in the Admin Console for the demo user, or via the Admin API if you automate setup elsewhere. The `keycloak-ssi config` script does **not** perform this step.
+4. **Select and grant verifiable credentials to the demo user**
+   On 26.7+, issuance requires an explicit per-user VC grant. Set `credentials.enabled` to the credential scopes you want to configure. The `keycloak-ssi config` command grants each selected credential to the demo user automatically.
 
 5. **Recreate Keycloak after flag changes**  
    Restart or recreate the Keycloak container so `KC_FEATURES` picks up the new flags.

--- a/oid4vci-deployment/src/config/client-scope-config.json
+++ b/oid4vci-deployment/src/config/client-scope-config.json
@@ -469,5 +469,62 @@
         }
       }
     ]
+  },
+  {
+    "name": "MobileDrivingLicence",
+    "protocol": "oid4vc",
+    "attributes": {
+      "include.in.token.scope": "true",
+      "vc.credential_configuration_id": "MobileDrivingLicence",
+      "vc.credential_identifier": "MobileDrivingLicence",
+      "vc.format": "mso_mdoc",
+      "vc.expiry_in_seconds": "31536000",
+      "vc.verifiable_credential_type": "org.iso.18013.5.1.mDL",
+      "vc.cryptographic_binding_methods_supported": "cose_key",
+      "vc.credential_signing_alg": "ES256",
+      "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Mobile Driving Licence\"}]",
+      "vc.issuer_did": "",
+      "vc.include_in_metadata": "true",
+      "vc.binding_required": "true",
+      "vc.binding_required_proof_types": "jwt"
+    },
+    "protocolMappers": [
+      {
+        "name": "given-name-mapper-mdoc",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-user-attribute-mapper",
+        "config": {
+          "claim.name": "given_name",
+          "userAttribute": "firstName",
+          "mdoc.namespace": "org.iso.18013.5.1",
+          "vc.mandatory": "true",
+          "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Given Name\"}]"
+        }
+      },
+      {
+        "name": "family-name-mapper-mdoc",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-user-attribute-mapper",
+        "config": {
+          "claim.name": "family_name",
+          "userAttribute": "lastName",
+          "mdoc.namespace": "org.iso.18013.5.1",
+          "vc.mandatory": "true",
+          "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Family Name\"}]"
+        }
+      },
+      {
+        "name": "document-number-mapper-mdoc",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "config": {
+          "claim.name": "document_number",
+          "staticValue": "D1234567",
+          "mdoc.namespace": "org.iso.18013.5.1",
+          "vc.mandatory": "true",
+          "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Document Number\"}]"
+        }
+      }
+    ]
   }
 ]

--- a/oid4vci-deployment/src/config/realm_configs/keycloak-config-dev.json
+++ b/oid4vci-deployment/src/config/realm_configs/keycloak-config-dev.json
@@ -55,7 +55,8 @@
       "optionalClientScopes": [
         "IdentityCredential",
         "SteuerberaterCredential",
-        "KMACredential"
+        "KMACredential",
+        "MobileDrivingLicence"
       ]
     },
     {
@@ -80,7 +81,8 @@
       "optionalClientScopes": [
         "IdentityCredential",
         "SteuerberaterCredential",
-        "KMACredential"
+        "KMACredential",
+        "MobileDrivingLicence"
       ]
     }
   ],
@@ -580,6 +582,66 @@
             "claim.name": "iat",
             "truncateToTimeUnit": "HOURS",
             "valueSource": "COMPUTE"
+          }
+        }
+      ]
+    },
+    {
+      "name": "MobileDrivingLicence",
+      "protocol": "oid4vc",
+      "attributes": {
+        "vc.credential_configuration_id": "MobileDrivingLicence",
+        "vc.credential_signing_alg": "ES256",
+        "vc.format": "mso_mdoc",
+        "include.in.token.scope": "true",
+        "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Mobile Driving Licence\"}]",
+        "vc.issuer_did": "$(env:ISSUER_DID)",
+        "vc.cryptographic_binding_methods_supported": "cose_key",
+        "vc.expiry_in_seconds": "31536000",
+        "vc.verifiable_credential_type": "org.iso.18013.5.1.mDL",
+        "vc.include_in_metadata": "true",
+        "vc.credential_identifier": "MobileDrivingLicence",
+        "vc.binding_required": "true",
+        "vc.binding_required_proof_types": "jwt"
+      },
+      "protocolMappers": [
+        {
+          "name": "given-name-mapper-mdoc",
+          "protocol": "oid4vc",
+          "protocolMapper": "oid4vc-user-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "given_name",
+            "userAttribute": "firstName",
+            "mdoc.namespace": "org.iso.18013.5.1",
+            "vc.mandatory": "true",
+            "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Given Name\"}]"
+          }
+        },
+        {
+          "name": "family-name-mapper-mdoc",
+          "protocol": "oid4vc",
+          "protocolMapper": "oid4vc-user-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "family_name",
+            "userAttribute": "lastName",
+            "mdoc.namespace": "org.iso.18013.5.1",
+            "vc.mandatory": "true",
+            "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Family Name\"}]"
+          }
+        },
+        {
+          "name": "document-number-mapper-mdoc",
+          "protocol": "oid4vc",
+          "protocolMapper": "oid4vc-static-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "document_number",
+            "staticValue": "D1234567",
+            "mdoc.namespace": "org.iso.18013.5.1",
+            "vc.mandatory": "true",
+            "vc.display": "[{\"locale\":\"en-US\",\"name\":\"Document Number\"}]"
           }
         }
       ]

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -165,7 +165,7 @@ if [[ -n "$CLIENT_SCOPES_CONFIG" ]]; then
       warn "Client scope already exists; skipping."
   done
 else
-  error "Could not resolve enabled credential client scopes."
+  error "Could not create enabled credential client scopes."
 fi
 
 # -----------------------------------------------------------------------------

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -129,12 +129,19 @@ ENABLED_CREDENTIALS=$(enabled_credentials_json)
 [[ "$(jq 'length' <<< "$ENABLED_CREDENTIALS")" -gt 0 ]] || \
   error "credentials.enabled must contain at least one credential name."
 
+MANAGED_CREDENTIALS=$(jq '[.[].name]' "$CLIENT_SCOPE_CONFIG_FILE")
+
 UNKNOWN_CREDENTIALS=$(jq -n \
   --argjson enabled "$ENABLED_CREDENTIALS" \
-  --slurpfile configured "$CLIENT_SCOPE_CONFIG_FILE" \
-  '$enabled - ($configured[0] | map(.name))')
+  --argjson managed "$MANAGED_CREDENTIALS" \
+  '$enabled - $managed')
 [[ "$(jq 'length' <<< "$UNKNOWN_CREDENTIALS")" -eq 0 ]] || \
   error "Unknown credentials in credentials.enabled: $(jq -r 'join(", ")' <<< "$UNKNOWN_CREDENTIALS")"
+
+DISABLED_CREDENTIALS=$(jq -n \
+  --argjson enabled "$ENABLED_CREDENTIALS" \
+  --argjson managed "$MANAGED_CREDENTIALS" \
+  '$managed - $enabled')
 
 CLIENT_SCOPES_CONFIG=$(jq \
   --argjson enabled "$ENABLED_CREDENTIALS" \
@@ -144,6 +151,9 @@ CLIENT_SCOPES_CONFIG=$(jq \
   "$CLIENT_SCOPE_CONFIG_FILE")
 
 log "Enabled credentials: $(jq -r 'join(", ")' <<< "$ENABLED_CREDENTIALS")"
+if [[ "$(jq 'length' <<< "$DISABLED_CREDENTIALS")" -gt 0 ]]; then
+  log "Disabled credentials: $(jq -r 'join(", ")' <<< "$DISABLED_CREDENTIALS")"
+fi
 
 # -----------------------------------------------------------------------------
 # Create client scopes
@@ -163,39 +173,85 @@ fi
 # -----------------------------------------------------------------------------
 log "Creating clients..."
 CLIENTS_CONFIG_FILE="$WORK_DIR/src/config/clients-config.json"
+[[ -f "$CLIENTS_CONFIG_FILE" ]] || error "clients-config.json not found."
 
-if [[ -f "$CLIENTS_CONFIG_FILE" && -f "$CLIENT_SCOPE_CONFIG_FILE" ]]; then
-  OPTIONAL_SCOPES=$(jq '[.[].name]' <<< "$CLIENT_SCOPES_CONFIG")
+OPTIONAL_SCOPES=$(jq '[.[].name]' <<< "$CLIENT_SCOPES_CONFIG")
 
-  jq -c '.[]' "$CLIENTS_CONFIG_FILE" | while read -r client; do
-    CLIENT_ID=$(echo "$client" | jq -r '.clientId')
-    
-    # Add the dynamic optional scopes to the client configuration
-    MODIFIED_CLIENT=$(echo "$client" | jq --argjson scopes "$OPTIONAL_SCOPES" '.optionalClientScopes = $scopes')
+jq -c '.[]' "$CLIENTS_CONFIG_FILE" | while read -r client; do
+  CLIENT_ID=$(echo "$client" | jq -r '.clientId')
 
-    if [[ "$CLIENT_ID" == "openid4vc-rest-api" ]]; then
-      MODIFIED_CLIENT=$(echo "$MODIFIED_CLIENT" | jq \
-        --arg CLIENT_SECRET "$CLIENTS_SECRET" \
-        --arg ISSUER_BACKEND_URL "$ISSUER_BACKEND_URL" \
-        --arg ISSUER_FRONTEND_URL "$ISSUER_FRONTEND_URL" \
-        '.secret = $CLIENT_SECRET |
-         .redirectUris += [$ISSUER_BACKEND_URL + "/*", "https://localhost:8443/callback"] |
-         .webOrigins += [$ISSUER_BACKEND_URL, "https://localhost:8443"] |
-         .attributes["post.logout.redirect.uris"] = ("##" + $ISSUER_FRONTEND_URL + "##" + $ISSUER_FRONTEND_URL + "/*")')
-    elif [[ "$CLIENT_ID" == "oid4vc-demo-public" ]]; then
-      MODIFIED_CLIENT=$(echo "$MODIFIED_CLIENT" | jq \
-        --arg TEST_CLIENT_URL "$TEST_CLIENT_URL" \
-        '.redirectUris = [$TEST_CLIENT_URL + "/*"] |
-         .webOrigins = [$TEST_CLIENT_URL] |
-         .attributes["post.logout.redirect.uris"] = ($TEST_CLIENT_URL + "##" + $TEST_CLIENT_URL + "/*")')
+  # Add the dynamic optional scopes to the client configuration
+  MODIFIED_CLIENT=$(echo "$client" | jq --argjson scopes "$OPTIONAL_SCOPES" '.optionalClientScopes = $scopes')
+
+  if [[ "$CLIENT_ID" == "openid4vc-rest-api" ]]; then
+    MODIFIED_CLIENT=$(echo "$MODIFIED_CLIENT" | jq \
+      --arg CLIENT_SECRET "$CLIENTS_SECRET" \
+      --arg ISSUER_BACKEND_URL "$ISSUER_BACKEND_URL" \
+      --arg ISSUER_FRONTEND_URL "$ISSUER_FRONTEND_URL" \
+      '.secret = $CLIENT_SECRET |
+       .redirectUris += [$ISSUER_BACKEND_URL + "/*", "https://localhost:8443/callback"] |
+       .webOrigins += [$ISSUER_BACKEND_URL, "https://localhost:8443"] |
+       .attributes["post.logout.redirect.uris"] = ("##" + $ISSUER_FRONTEND_URL + "##" + $ISSUER_FRONTEND_URL + "/*")')
+  elif [[ "$CLIENT_ID" == "oid4vc-demo-public" ]]; then
+    MODIFIED_CLIENT=$(echo "$MODIFIED_CLIENT" | jq \
+      --arg TEST_CLIENT_URL "$TEST_CLIENT_URL" \
+      '.redirectUris = [$TEST_CLIENT_URL + "/*"] |
+       .webOrigins = [$TEST_CLIENT_URL] |
+       .attributes["post.logout.redirect.uris"] = ($TEST_CLIENT_URL + "##" + $TEST_CLIENT_URL + "/*")')
+  fi
+
+  if ! echo "$MODIFIED_CLIENT" | kcadm create clients -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1; then
+    CLIENT_UUID=$(kcadm get clients -r "$KEYCLOAK_REALM" -q clientId="$CLIENT_ID" --fields id | jq -r '.[0].id // empty')
+    [[ -n "$CLIENT_UUID" ]] || error "Failed to create or find client '$CLIENT_ID'."
+    warn "Client '$CLIENT_ID' already exists; reconciling its credential scopes."
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Reconcile managed optional client scopes
+# -----------------------------------------------------------------------------
+# Client creation is intentionally idempotent. Keep existing clients in sync when
+# credentials.enabled changes instead of relying on optionalClientScopes from the
+# create payload, which is ignored when a client already exists.
+log "Reconciling credential scopes assigned to clients..."
+REALM_CLIENT_SCOPES=$(kcadm get client-scopes -r "$KEYCLOAK_REALM" --fields id,name)
+
+jq -r '.[].clientId' "$CLIENTS_CONFIG_FILE" | while read -r client_id; do
+  client_uuid=$(kcadm get clients -r "$KEYCLOAK_REALM" -q clientId="$client_id" --fields id | jq -r '.[0].id // empty')
+  [[ -n "$client_uuid" ]] || error "Client '$client_id' not found during scope reconciliation."
+
+  optional_scope_ids=$(kcadm get "clients/$client_uuid/optional-client-scopes" -r "$KEYCLOAK_REALM" --fields id \
+    | jq '[.[].id]')
+
+  jq -r '.[]' <<< "$MANAGED_CREDENTIALS" | while read -r credential; do
+    scope_id=$(jq -r --arg name "$credential" '.[] | select(.name == $name) | .id' <<< "$REALM_CLIENT_SCOPES" | head -n1)
+    [[ -n "$scope_id" ]] || continue
+
+    if jq -e --arg credential "$credential" 'index($credential) != null' <<< "$ENABLED_CREDENTIALS" >/dev/null; then
+      if ! jq -e --arg id "$scope_id" 'index($id) != null' <<< "$optional_scope_ids" >/dev/null; then
+        log "Assigning credential '$credential' to client '$client_id'."
+        kcadm update "clients/$client_uuid/optional-client-scopes/$scope_id" -r "$KEYCLOAK_REALM" >/dev/null || \
+          error "Failed to assign credential '$credential' to client '$client_id'."
+      fi
+    elif jq -e --arg id "$scope_id" 'index($id) != null' <<< "$optional_scope_ids" >/dev/null; then
+      log "Unassigning disabled credential '$credential' from client '$client_id'."
+      kcadm delete "clients/$client_uuid/optional-client-scopes/$scope_id" -r "$KEYCLOAK_REALM" >/dev/null || \
+        error "Failed to unassign credential '$credential' from client '$client_id'."
     fi
-
-    echo "$MODIFIED_CLIENT" | kcadm create clients -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1 || \
-      warn "Client '$CLIENT_ID' already exists; skipping."
   done
-else
-  warn "clients-config.json or client-scope-config.json not found; skipping client creation."
-fi
+done
+
+# Remove disabled scopes after unassigning them so they are no longer advertised
+# in issuer metadata and can be cleanly recreated if enabled again later.
+log "Removing disabled credential scopes..."
+jq -r '.[]' <<< "$DISABLED_CREDENTIALS" | while read -r credential; do
+  scope_id=$(jq -r --arg name "$credential" '.[] | select(.name == $name) | .id' <<< "$REALM_CLIENT_SCOPES" | head -n1)
+  if [[ -n "$scope_id" ]]; then
+    log "Removing disabled credential scope '$credential'."
+    kcadm delete "client-scopes/$scope_id" -r "$KEYCLOAK_REALM" >/dev/null || \
+      error "Failed to remove disabled credential scope '$credential'."
+  fi
+done
 
 # Validate OID4VCI configuration
 # -----------------------------------------------------------------------------
@@ -207,6 +263,11 @@ response=$(curl -ks "$KEYCLOAK_ADMIN_ADDR/.well-known/openid-credential-issuer/r
 jq -r '.[].name' <<< "$CLIENT_SCOPES_CONFIG" | while read -r credential; do
   jq -e --arg c "$credential" '."credential_configurations_supported"[$c]' <<< "$response" >/dev/null || \
     error "Configuration missing: '$credential' not found in OID4VCI configuration."
+done
+
+jq -r '.[]' <<< "$DISABLED_CREDENTIALS" | while read -r credential; do
+  jq -e --arg c "$credential" '."credential_configurations_supported"[$c] == null' <<< "$response" >/dev/null || \
+    error "Configuration stale: disabled credential '$credential' is still advertised."
 done
 
 success "Keycloak server is running and OID4VCI credentials are configured successfully."

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -120,17 +120,42 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Select enabled credential client scopes
+# -----------------------------------------------------------------------------
+CLIENT_SCOPE_CONFIG_FILE="$WORK_DIR/src/config/client-scope-config.json"
+[[ -f "$CLIENT_SCOPE_CONFIG_FILE" ]] || error "client-scope-config.json not found."
+
+ENABLED_CREDENTIALS=$(enabled_credentials_json)
+[[ "$(jq 'length' <<< "$ENABLED_CREDENTIALS")" -gt 0 ]] || \
+  error "credentials.enabled must contain at least one credential name."
+
+UNKNOWN_CREDENTIALS=$(jq -n \
+  --argjson enabled "$ENABLED_CREDENTIALS" \
+  --slurpfile configured "$CLIENT_SCOPE_CONFIG_FILE" \
+  '$enabled - ($configured[0] | map(.name))')
+[[ "$(jq 'length' <<< "$UNKNOWN_CREDENTIALS")" -eq 0 ]] || \
+  error "Unknown credentials in credentials.enabled: $(jq -r 'join(", ")' <<< "$UNKNOWN_CREDENTIALS")"
+
+CLIENT_SCOPES_CONFIG=$(jq \
+  --argjson enabled "$ENABLED_CREDENTIALS" \
+  --arg ISSUER_DID "$KEYCLOAK_ISSUER_DID" \
+  'map(select(.name as $name | $enabled | index($name)))
+   | map(.attributes["vc.issuer_did"] = $ISSUER_DID)' \
+  "$CLIENT_SCOPE_CONFIG_FILE")
+
+log "Enabled credentials: $(jq -r 'join(", ")' <<< "$ENABLED_CREDENTIALS")"
+
+# -----------------------------------------------------------------------------
 # Create client scopes
 # -----------------------------------------------------------------------------
 log "Creating client scopes..."
-if [[ -f "$WORK_DIR/src/config/client-scope-config.json" ]]; then
-  CLIENT_SCOPES_CONFIG=$(jq --arg ISSUER_DID "$KEYCLOAK_ISSUER_DID" 'map(.attributes["vc.issuer_did"] = $ISSUER_DID)' "$WORK_DIR/src/config/client-scope-config.json")
+if [[ -n "$CLIENT_SCOPES_CONFIG" ]]; then
   echo "$CLIENT_SCOPES_CONFIG" | jq -c '.[]' | while read -r scope; do
     echo "$scope" | kcadm create client-scopes -r "$KEYCLOAK_REALM" -f - >/dev/null 2>&1 || \
       warn "Client scope already exists; skipping."
   done
 else
-  warn "client-scope-config.json not found; skipping client scopes creation."
+  error "Could not resolve enabled credential client scopes."
 fi
 
 # -----------------------------------------------------------------------------
@@ -138,11 +163,9 @@ fi
 # -----------------------------------------------------------------------------
 log "Creating clients..."
 CLIENTS_CONFIG_FILE="$WORK_DIR/src/config/clients-config.json"
-CLIENT_SCOPE_CONFIG_FILE="$WORK_DIR/src/config/client-scope-config.json"
 
 if [[ -f "$CLIENTS_CONFIG_FILE" && -f "$CLIENT_SCOPE_CONFIG_FILE" ]]; then
-  # Dynamically get all scope names from client-scope-config.json
-  OPTIONAL_SCOPES=$(jq '[.[].name]' "$CLIENT_SCOPE_CONFIG_FILE")
+  OPTIONAL_SCOPES=$(jq '[.[].name]' <<< "$CLIENT_SCOPES_CONFIG")
 
   jq -c '.[]' "$CLIENTS_CONFIG_FILE" | while read -r client; do
     CLIENT_ID=$(echo "$client" | jq -r '.clientId')
@@ -180,8 +203,8 @@ log "Validating OID4VCI configuration..."
 response=$(curl -ks "$KEYCLOAK_ADMIN_ADDR/.well-known/openid-credential-issuer/realms/$KEYCLOAK_REALM")
 [[ -z "$response" ]] && error "No response from Keycloak OIDC credential issuer endpoint."
 
-# Dynamically validate all credentials from the configuration file
-jq -r '.[].name' "$CLIENT_SCOPE_CONFIG_FILE" | while read -r credential; do
+# Validate only credentials selected in credentials.enabled.
+jq -r '.[].name' <<< "$CLIENT_SCOPES_CONFIG" | while read -r credential; do
   jq -e --arg c "$credential" '."credential_configurations_supported"[$c]' <<< "$response" >/dev/null || \
     error "Configuration missing: '$credential' not found in OID4VCI configuration."
 done

--- a/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
+++ b/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
@@ -61,6 +61,32 @@ kcadm set-password -r "$KEYCLOAK_REALM" --username "$USERS_FRANCIS_NAME" --new-p
 success "Password ensured for Francis."
 
 # -----------------------------------------------------------------------------
+# Grant enabled credentials to Francis
+# -----------------------------------------------------------------------------
+# Keycloak requires an explicit per-user grant before a credential can be
+# issued. Keep the demo user synchronized with credentials.enabled so newly
+# enabled samples can be tested immediately after running `keycloak-ssi config`.
+log "Granting enabled credentials to user Francis..."
+FRANCIS_USER_ID=$(kcadm get users -r "$KEYCLOAK_REALM" -q username="$USERS_FRANCIS_NAME" --fields id | jq -r '.[0].id // empty')
+[[ -n "$FRANCIS_USER_ID" ]] || error "Could not find user Francis to grant credentials."
+
+ENABLED_CREDENTIALS=$(enabled_credentials_json)
+GRANTED_CREDENTIALS=$(kcadm get "users/$FRANCIS_USER_ID/vc/credentials" -r "$KEYCLOAK_REALM")
+
+jq -r '.[]' <<< "$ENABLED_CREDENTIALS" | while read -r credential; do
+  if jq -e --arg credential "$credential" \
+    'any(.[]; .credentialScopeName == $credential)' <<< "$GRANTED_CREDENTIALS" >/dev/null; then
+    log "Credential '$credential' is already granted to Francis."
+    continue
+  fi
+
+  jq -n --arg credential "$credential" '{credentialScopeName: $credential}' | \
+    kcadm create "users/$FRANCIS_USER_ID/vc/credentials" -r "$KEYCLOAK_REALM" -f - >/dev/null || \
+    error "Failed to grant credential '$credential' to Francis."
+  success "Credential '$credential' granted to Francis."
+done
+
+# -----------------------------------------------------------------------------
 # Conditionally assign 'credential-offer-create' realm role to Francis
 # This realm role grants permission to create credential offers.
 # Only assigned when KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE is true.

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -97,6 +97,16 @@ setup_environment() {
 # -----------------------------------------------------------------------------
 export_yaml_as_env() {
     local yaml_files=("$@")
+    local credentials_enabled_was_set=false
+    local credentials_enabled_override=""
+
+    # Environment variables have higher precedence than YAML configuration.
+    # Remember this value before the YAML passes so credentials.enabled does not
+    # overwrite an explicit CREDENTIALS_ENABLED supplied by the caller.
+    if [[ -v CREDENTIALS_ENABLED ]]; then
+        credentials_enabled_was_set=true
+        credentials_enabled_override="$CREDENTIALS_ENABLED"
+    fi
     
     # Filter to only existing files (defensive check)
     local existing_files=()
@@ -131,6 +141,9 @@ export_yaml_as_env() {
         [[ -z "$key" ]] && continue
         local env_var_name
         env_var_name=$(echo "$key" | tr '[:lower:]' '[:upper:]' | tr '.' '_')
+        if [[ "$env_var_name" == "CREDENTIALS_ENABLED" && "$credentials_enabled_was_set" == "true" ]]; then
+            value="$credentials_enabled_override"
+        fi
         # Export the raw value
         export "$env_var_name"="$value"
         echo "$env_var_name=$value"
@@ -156,7 +169,11 @@ export_yaml_as_env() {
         env_var_name=$(echo "$key" | tr '[:lower:]' '[:upper:]' | tr '.' '_')
         # Resolve placeholders using envsubst, now that all variables are in the environment
         local resolved_value
-        resolved_value=$(echo "$value" | envsubst)
+        if [[ "$env_var_name" == "CREDENTIALS_ENABLED" && "$credentials_enabled_was_set" == "true" ]]; then
+            resolved_value="$credentials_enabled_override"
+        else
+            resolved_value=$(echo "$value" | envsubst)
+        fi
         # Re-export the variable with its resolved value
         export "$env_var_name"="$resolved_value"
         case "$key" in

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -22,6 +22,33 @@ error()   { printf "\n${RED}[ERROR]${NC} %s\n" "$*" >&2; exit 1; }
 success() { printf "\n${GREEN}[SUCCESS]${NC} %s\n" "$*"; }
 debug()   { printf "\n${BLUE}[DEBUG]${NC} %s\n" "$*"; }
 
+# Return the configured credential names as a JSON array. Credential selection
+# is stored as a comma-separated string so it works with the existing YAML-to-env
+# loader and can be overridden with CREDENTIALS_ENABLED.
+enabled_credentials_json() {
+    jq -cn --arg enabled "${CREDENTIALS_ENABLED:-}" '
+        $enabled
+        | split(",")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 0))
+        | reduce .[] as $credential ([];
+            if index($credential) then . else . + [$credential] end)
+    '
+}
+
+credential_is_enabled() {
+    local credential_name="$1"
+    enabled_credentials_json | jq -e --arg credential "$credential_name" 'index($credential) != null' >/dev/null
+}
+
+append_keycloak_feature() {
+    local feature="$1"
+    case ",${KEYCLOAK_FEATURES}," in
+        *",${feature},"*) ;;
+        *) KEYCLOAK_FEATURES="${KEYCLOAK_FEATURES},${feature}" ;;
+    esac
+}
+
 
 # -----------------------------------------------------------------------------
 # Environment Setup
@@ -172,9 +199,11 @@ export_yaml_as_env() {
     KEYCLOAK_FEATURES="${KEYCLOAK_FEATURES:-oid4vc-vci}"
 
     [[ "${KEYCLOAK_ENABLE_PREAUTH_CODE:-}" == "true" ]] && \
-        KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-preauth-code"
+        append_keycloak_feature "oid4vc-vci-preauth-code"
     [[ "${KEYCLOAK_ENABLE_REST_CREDENTIAL_OFFER:-}" == "true" ]] && \
-        KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-rest-credential-offer"
+        append_keycloak_feature "oid4vc-vci-rest-credential-offer"
+    credential_is_enabled "MobileDrivingLicence" && \
+        append_keycloak_feature "oid4vc-mdoc"
     export KEYCLOAK_FEATURES
 
     # Remap only — do not resolve "latest" here (that hits GitHub and would break

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -24,7 +24,7 @@ debug()   { printf "\n${BLUE}[DEBUG]${NC} %s\n" "$*"; }
 
 # Return the configured credential names as a JSON array. Credential selection
 # is stored as a comma-separated string so it works with the existing YAML-to-env
-# loader and can be overridden with CREDENTIALS_ENABLED.
+# loader and can be overridden through config.override.yaml.
 enabled_credentials_json() {
     jq -cn --arg enabled "${CREDENTIALS_ENABLED:-}" '
         $enabled
@@ -97,16 +97,6 @@ setup_environment() {
 # -----------------------------------------------------------------------------
 export_yaml_as_env() {
     local yaml_files=("$@")
-    local credentials_enabled_was_set=false
-    local credentials_enabled_override=""
-
-    # Environment variables have higher precedence than YAML configuration.
-    # Remember this value before the YAML passes so credentials.enabled does not
-    # overwrite an explicit CREDENTIALS_ENABLED supplied by the caller.
-    if [[ -v CREDENTIALS_ENABLED ]]; then
-        credentials_enabled_was_set=true
-        credentials_enabled_override="$CREDENTIALS_ENABLED"
-    fi
     
     # Filter to only existing files (defensive check)
     local existing_files=()
@@ -141,9 +131,6 @@ export_yaml_as_env() {
         [[ -z "$key" ]] && continue
         local env_var_name
         env_var_name=$(echo "$key" | tr '[:lower:]' '[:upper:]' | tr '.' '_')
-        if [[ "$env_var_name" == "CREDENTIALS_ENABLED" && "$credentials_enabled_was_set" == "true" ]]; then
-            value="$credentials_enabled_override"
-        fi
         # Export the raw value
         export "$env_var_name"="$value"
         echo "$env_var_name=$value"
@@ -169,11 +156,7 @@ export_yaml_as_env() {
         env_var_name=$(echo "$key" | tr '[:lower:]' '[:upper:]' | tr '.' '_')
         # Resolve placeholders using envsubst, now that all variables are in the environment
         local resolved_value
-        if [[ "$env_var_name" == "CREDENTIALS_ENABLED" && "$credentials_enabled_was_set" == "true" ]]; then
-            resolved_value="$credentials_enabled_override"
-        else
-            resolved_value=$(echo "$value" | envsubst)
-        fi
+        resolved_value=$(echo "$value" | envsubst)
         # Re-export the variable with its resolved value
         export "$env_var_name"="$resolved_value"
         case "$key" in

--- a/oid4vci-deployment/src/utils/import_kc_config.sh
+++ b/oid4vci-deployment/src/utils/import_kc_config.sh
@@ -36,16 +36,37 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Create temporary JSON file with conditional realmRoles
+# Create temporary JSON with conditional roles and enabled credentials
 # ---------------------------------------------------------------------------
 TEMP_CONFIG_FILE="$WORK_DIR/temp-keycloak-config.json"
 if [[ "$KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE" == "true" ]]; then
-    log "Creating temporary config with credential-offer-create role..."
-    jq '.users[0].realmRoles = ["credential-offer-create"]' "$CLI_REALM_FILE" > "$TEMP_CONFIG_FILE"
+    REALM_ROLES='["credential-offer-create"]'
 else
-    log "Creating temporary config without credential-offer-create role..."
-    jq '.users[0].realmRoles = []' "$CLI_REALM_FILE" > "$TEMP_CONFIG_FILE"
+    REALM_ROLES='[]'
 fi
+
+ENABLED_CREDENTIALS=$(enabled_credentials_json)
+[[ "$(jq 'length' <<< "$ENABLED_CREDENTIALS")" -gt 0 ]] || \
+    error "credentials.enabled must contain at least one credential name."
+
+UNKNOWN_CREDENTIALS=$(jq -n \
+    --argjson enabled "$ENABLED_CREDENTIALS" \
+    --slurpfile realm "$CLI_REALM_FILE" \
+    '$enabled - ($realm[0].clientScopes | map(.name))')
+[[ "$(jq 'length' <<< "$UNKNOWN_CREDENTIALS")" -eq 0 ]] || \
+    error "Unknown credentials in credentials.enabled: $(jq -r 'join(", ")' <<< "$UNKNOWN_CREDENTIALS")"
+
+log "Creating temporary config for credentials: $(jq -r 'join(", ")' <<< "$ENABLED_CREDENTIALS")"
+jq \
+    --argjson realm_roles "$REALM_ROLES" \
+    --argjson enabled "$ENABLED_CREDENTIALS" '
+    .users[0].realmRoles = $realm_roles
+    | .clientScopes |= map(select(.name as $name | $enabled | index($name)))
+    | .clients |= map(
+        .optionalClientScopes = ((.optionalClientScopes // [])
+            | map(select(. as $name | $enabled | index($name))))
+      )
+    ' "$CLI_REALM_FILE" > "$TEMP_CONFIG_FILE"
 
 # ---------------------------------------------------------------------------
 # Run CLI JAR to import realm configuration


### PR DESCRIPTION
Adds an opt-in `MobileDrivingLicence` sample credential using the `mso_mdoc` format to `oid4vci-deployment`.

Because mDoc support is currently available only in Keycloak main/nightly, the sample is excluded from the default credential list. Enabling it automatically adds the experimental `oid4vc-mdoc` feature.

## Changes

- Add configurable credential selection through `credentials.enabled`.
- Keep the existing SD-JWT credentials enabled by default.
- Add the `MobileDrivingLicence` credential with:
  - Format: `mso_mdoc`
  - DocType: `org.iso.18013.5.1.mDL`
  - Namespace: `org.iso.18013.5.1`
  - Signing algorithm: ES256
  - Holder binding: `cose_key`
  - Proof type: JWT
- Add the following mDL claims:
  - `given_name` from the user's first name
  - `family_name` from the user's last name
  - `document_number` using the static demo value `D1234567`
- Automatically enable `oid4vc-mdoc` when the sample credential is selected.
- Filter credential scopes and client assignments in both scripted configuration and realm import.
- Document nightly enablement, user credential grants, issuance testing, and the limitations of the sample.

closes #1053