### PR TITLE
feat: add VC grants for Keycloak 26.7+

### DIFF
--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -77,6 +77,11 @@ users:
     name: "francis"
     # Test user password
     password: "francis"
+    # Verifiable credential scopes to grant this user (Keycloak 26.7+ required)
+    credential_scopes:
+      - "IdentityCredential"
+      - "SteuerberaterCredential"
+      - "KMACredential"
     # Francis test keystore
     keystore:
       path: "${PROJECT_TARGET_DIR}/francis_kc_keystore.pkcs12"

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -14,7 +14,7 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
    Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
 4. **Grant verifiable credentials to the demo user**
-   On 26.7+, issuance requires an explicit per-user VC grant for each credential scope. The `keycloak-ssi config` script **automatically grants** credentials listed in `config.yaml` under `users.<username>.credential_scopes`. To customize which credentials are assigned, edit the `credential_scopes` list. The script detects the Keycloak version and only runs the grant step on 26.7+.
+   On 26.7+, issuance requires an explicit per-user VC grant for each credential scope. The `keycloak-ssi config` script **automatically grants** credentials listed in `config.yaml` (or `config.override.yaml`) under `users.francis.credential_scopes`. To customize which credentials are assigned, edit the `credential_scopes` list. The script detects the Keycloak version and only runs the grant step on 26.7+.
 
 5. **Recreate Keycloak after flag changes**  
    Restart or recreate the Keycloak container so `KC_FEATURES` picks up the new flags.

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -13,8 +13,8 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
 3. **Enable REST credential-offer creation**  
    Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
-4. **Grant verifiable credentials to the demo user** 
-   On 26.7+, issuance requires an explicit per-user VC grant for each credential scope (IdentityCredential, SteuerberaterCredential, KMACredential). Grant these in the Admin Console for the demo user, or via the Admin API if you automate setup elsewhere. The `keycloak-ssi config` script does **not** perform this step.
+4. **Grant verifiable credentials to the demo user**
+   On 26.7+, issuance requires an explicit per-user VC grant for each credential scope. The `keycloak-ssi config` script **automatically grants** credentials listed in `config.yaml` under `users.<username>.credential_scopes`. To customize which credentials are assigned, edit the `credential_scopes` list. The script detects the Keycloak version and only runs the grant step on 26.7+.
 
 5. **Recreate Keycloak after flag changes**  
    Restart or recreate the Keycloak container so `KC_FEATURES` picks up the new flags.
@@ -26,6 +26,14 @@ keycloak:
   enable_preauth_code: true
   enable_rest_credential_offer: true
   enable_credential_offer_create: true
+
+# Customize credential scopes per user (defaults match config.yaml)
+users:
+  francis:
+    credential_scopes:
+      - "IdentityCredential"
+      - "SteuerberaterCredential"
+      - "KMACredential"
 ```
 
 ### Verification

--- a/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
+++ b/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
@@ -118,7 +118,7 @@ if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
     ) || ADMIN_TOKEN=""
 
     if [[ -z "$ADMIN_TOKEN" ]]; then
-      warn "Failed to obtain admin token for credential grants."
+      error "Failed to obtain admin token for credential grants."
     else
       for scope in "${CREDENTIAL_SCOPES[@]}"; do
         log "Granting credential scope '$scope' to '$USERS_FRANCIS_NAME'..."

--- a/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
+++ b/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
@@ -16,7 +16,7 @@ init_script
 ensure_keycloak_install_dir_resolved
 
 # -----------------------------------------------------------------------------
-# Get admin token using environment variables for credentials
+# Authenticate admin
 # -----------------------------------------------------------------------------
 log "Obtaining admin token..."
 kcadm config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$(kc_truststore_path)"
@@ -24,14 +24,9 @@ kcadm config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master --user "
 success "Admin token obtained."
 
 # -----------------------------------------------------------------------------
-# Read the direct access property of the openid4vc-rest-api client
+# Configure openid4vc-rest-api client
 # -----------------------------------------------------------------------------
-log "Reading direct access property of the openid4vc-rest-api client..."
-kcadm get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields 'id,directAccessGrantsEnabled' || true
-
-# -----------------------------------------------------------------------------
-# Store property ACC_CLIENT_ID in an environment variable
-# -----------------------------------------------------------------------------
+log "Configuring openid4vc-rest-api client..."
 export ACC_CLIENT_ID=$(kcadm get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields id | jq -r '.[0].id')
 log "Stored openid4vc-rest-api Client ID: $ACC_CLIENT_ID"
 
@@ -43,7 +38,7 @@ kcadm update clients/$ACC_CLIENT_ID -r "$KEYCLOAK_REALM" -s directAccessGrantsEn
 success "Direct grant enabled."
 
 # -----------------------------------------------------------------------------
-# Create a user named Francis
+# Create user Francis
 # -----------------------------------------------------------------------------
 log "Creating user Francis if not exists..."
 if ! kcadm get users -r "$KEYCLOAK_REALM" -q username=francis | jq -e '.[0].id' >/dev/null 2>&1; then
@@ -60,10 +55,96 @@ log "Setting password for user Francis..."
 kcadm set-password -r "$KEYCLOAK_REALM" --username "$USERS_FRANCIS_NAME" --new-password "$USERS_FRANCIS_PASSWORD" || true
 success "Password ensured for Francis."
 
+# Resolve Francis user ID once for reuse below
+FRANCIS_USER_ID=$(kcadm get users -r "$KEYCLOAK_REALM" -q username="$USERS_FRANCIS_NAME" --fields id | jq -r '.[0].id')
+
 # -----------------------------------------------------------------------------
-# Conditionally assign 'credential-offer-create' realm role to Francis
-# This realm role grants permission to create credential offers.
-# Only assigned when KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE is true.
+# Grant verifiable credentials (Keycloak 26.7+ only)
+# Skips SNAPSHOT builds since feature availability is unknown.
+# -----------------------------------------------------------------------------
+KC_MAJOR_MINOR=""
+if [[ -n "${KEYCLOAK_VERSION:-}" ]] && [[ "$KEYCLOAK_VERSION" != *"SNAPSHOT"* ]]; then
+  if [[ "$KEYCLOAK_VERSION" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    KC_MAJOR_MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+  fi
+fi
+
+kc_version_gte() {
+  local required="$1" actual="$2"
+  local r_major r_minor a_major a_minor
+  IFS='.' read -r r_major r_minor <<< "$required"
+  IFS='.' read -r a_major a_minor <<< "$actual"
+  [[ "$a_major" -gt "$r_major" ]] ||
+    { [[ "$a_major" -eq "$r_major" ]] && [[ "$a_minor" -ge "$r_minor" ]]; }
+}
+
+if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
+  log "Keycloak $KEYCLOAK_VERSION (>= 26.7). Granting verifiable credentials..."
+
+  CONFIG_FILE="$WORK_DIR/config.yaml"
+  OVERRIDE_FILE="$WORK_DIR/config.override.yaml"
+  CREDENTIAL_SCOPES=()
+
+  if [[ -f "$CONFIG_FILE" ]]; then
+    YQ_ARGS=("$CONFIG_FILE")
+    [[ -f "$OVERRIDE_FILE" ]] && YQ_ARGS+=("$OVERRIDE_FILE")
+
+    while IFS= read -r scope; do
+      CREDENTIAL_SCOPES+=("$scope")
+    done < <(
+      yq eval-all '
+        . as $item ireduce ({}; . * $item)
+        | .users.francis.credential_scopes // []
+        | .[]
+      ' "${YQ_ARGS[@]}" 2>/dev/null
+    )
+  fi
+
+  if [[ ${#CREDENTIAL_SCOPES[@]} -gt 0 ]]; then
+    ADMIN_TOKEN=$(\
+      curl -k -s --fail-with-body -X POST \
+        "$KEYCLOAK_ADMIN_ADDR/realms/master/protocol/openid-connect/token" \
+        -d "client_id=admin-cli" \
+        -d "username=$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" \
+        -d "password=$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD" \
+        -d "grant_type=password" |
+      jq -er '.access_token'
+    ) || ADMIN_TOKEN=""
+
+    if [[ -z "$ADMIN_TOKEN" ]]; then
+      warn "Failed to obtain admin token for credential grants."
+    else
+      for scope in "${CREDENTIAL_SCOPES[@]}"; do
+        log "Granting credential scope '$scope' to '$USERS_FRANCIS_NAME'..."
+
+        HTTP_CODE=$(curl -k -s -o /dev/null -w '%{http_code}' \
+          -X POST "$KEYCLOAK_ADMIN_ADDR/admin/realms/$KEYCLOAK_REALM/users/$FRANCIS_USER_ID/vc/credentials" \
+          -H 'Content-Type: application/json' \
+          -H "Authorization: Bearer $ADMIN_TOKEN" \
+          -d "$(jq -n --arg scope "$scope" '{credentialScopeName: $scope}')")
+
+        case "$HTTP_CODE" in
+          200|201) success "Credential scope '$scope' granted." ;;
+          409) warn "Credential scope '$scope' already granted; skipping." ;;
+          *) warn "Could not grant '$scope' (HTTP $HTTP_CODE)." ;;
+        esac
+      done
+    fi
+  else
+    warn "No credential_scopes configured for user '$USERS_FRANCIS_NAME'."
+  fi
+else
+  if [[ "${KEYCLOAK_VERSION:-}" == *"SNAPSHOT"* ]]; then
+    warn "SNAPSHOT build ($KEYCLOAK_VERSION); skipping credential grants (feature availability unknown)."
+  elif [[ -z "$KC_MAJOR_MINOR" ]]; then
+    warn "Could not determine Keycloak version from '${KEYCLOAK_VERSION:-unknown}'; skipping credential grants."
+  else
+    warn "Keycloak $KEYCLOAK_VERSION < 26.7; skipping credential grants."
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Assign credential-offer-create role (when enabled)
 # -----------------------------------------------------------------------------
 CREDENTIAL_OFFER_ROLE="credential-offer-create"
 if [[ "$KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE" == "true" ]]; then
@@ -71,12 +152,11 @@ if [[ "$KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE" == "true" ]]; then
 
   if kcadm get roles/$CREDENTIAL_OFFER_ROLE -r "$KEYCLOAK_REALM" >/dev/null 2>&1; then
     log "Assigning realm role '$CREDENTIAL_OFFER_ROLE' to user Francis..."
-    FRANCIS_USER_ID=$(kcadm get users -r "$KEYCLOAK_REALM" -q username="$USERS_FRANCIS_NAME" --fields id | jq -r '.[0].id')
     if [ -n "$FRANCIS_USER_ID" ] && [ "$FRANCIS_USER_ID" != "null" ]; then
       kcadm add-roles -r "$KEYCLOAK_REALM" \
         --uid "$FRANCIS_USER_ID" \
         --rolename $CREDENTIAL_OFFER_ROLE || \
-        warn "Failed to assign '$CREDENTIAL_OFFER_ROLE' role to user Francis (it may already be assigned)."
+        warn "Failed to assign '$CREDENTIAL_OFFER_ROLE' role (may already be assigned)."
       success "Realm role '$CREDENTIAL_OFFER_ROLE' assigned to Francis."
     else
       error "Could not find user Francis to assign realm role '$CREDENTIAL_OFFER_ROLE'."
@@ -85,11 +165,11 @@ if [[ "$KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE" == "true" ]]; then
     error "Realm role '$CREDENTIAL_OFFER_ROLE' does not exist in realm '$KEYCLOAK_REALM'."
   fi
 else
-  log "Skipping '$CREDENTIAL_OFFER_ROLE' role assignment (disabled in configuration)."
+  log "Skipping '$CREDENTIAL_OFFER_ROLE' role assignment (disabled)."
 fi
 
 # -----------------------------------------------------------------------------
-# Prepare user key proof header if not existent
+# Generate user key proof if needed
 # -----------------------------------------------------------------------------
 if [ ! -f "$PROJECT_TARGET_DIR/user_key_proof_header.json" ]; then
   log "Generating keypair for user..."

--- a/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
+++ b/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
@@ -60,11 +60,16 @@ FRANCIS_USER_ID=$(kcadm get users -r "$KEYCLOAK_REALM" -q username="$USERS_FRANC
 
 # -----------------------------------------------------------------------------
 # Grant verifiable credentials (Keycloak 26.7+ only)
-# Skips SNAPSHOT builds since feature availability is unknown.
+# Query the running server, not config — KEYCLOAK_VERSION (tarball) and
+# KEYCLOAK_IMAGE_TAG (docker) are independent and may diverge.
 # -----------------------------------------------------------------------------
 KC_MAJOR_MINOR=""
-if [[ -n "${KEYCLOAK_VERSION:-}" ]] && [[ "$KEYCLOAK_VERSION" != *"SNAPSHOT"* ]]; then
-  if [[ "$KEYCLOAK_VERSION" =~ ^([0-9]+)\.([0-9]+) ]]; then
+KC_VERSION_RAW=""
+
+KC_VERSION_RAW=$(kcadm get serverinfo 2>/dev/null | jq -r '.systemInfo.version // empty' 2>/dev/null) || KC_VERSION_RAW=""
+
+if [[ -n "$KC_VERSION_RAW" ]] && [[ "$KC_VERSION_RAW" != *"SNAPSHOT"* ]]; then
+  if [[ "$KC_VERSION_RAW" =~ ^([0-9]+)\.([0-9]+) ]]; then
     KC_MAJOR_MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
   fi
 fi
@@ -79,7 +84,7 @@ kc_version_gte() {
 }
 
 if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
-  log "Keycloak $KEYCLOAK_VERSION (>= 26.7). Granting verifiable credentials..."
+  log "Keycloak $KC_VERSION_RAW (>= 26.7). Granting verifiable credentials..."
 
   CONFIG_FILE="$WORK_DIR/config.yaml"
   OVERRIDE_FILE="$WORK_DIR/config.override.yaml"
@@ -95,6 +100,7 @@ if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
       yq eval-all '
         . as $item ireduce ({}; . * $item)
         | .users.francis.credential_scopes // []
+        | map(envsubst)
         | .[]
       ' "${YQ_ARGS[@]}" 2>/dev/null
     )
@@ -104,10 +110,10 @@ if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
     ADMIN_TOKEN=$(\
       curl -k -s --fail-with-body -X POST \
         "$KEYCLOAK_ADMIN_ADDR/realms/master/protocol/openid-connect/token" \
-        -d "client_id=admin-cli" \
-        -d "username=$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" \
-        -d "password=$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD" \
-        -d "grant_type=password" |
+        --data-urlencode "client_id=admin-cli" \
+        --data-urlencode "username=$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" \
+        --data-urlencode "password=$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD" \
+        --data-urlencode "grant_type=password" |
       jq -er '.access_token'
     ) || ADMIN_TOKEN=""
 
@@ -134,12 +140,12 @@ if [[ -n "$KC_MAJOR_MINOR" ]] && kc_version_gte "26.7" "$KC_MAJOR_MINOR"; then
     warn "No credential_scopes configured for user '$USERS_FRANCIS_NAME'."
   fi
 else
-  if [[ "${KEYCLOAK_VERSION:-}" == *"SNAPSHOT"* ]]; then
-    warn "SNAPSHOT build ($KEYCLOAK_VERSION); skipping credential grants (feature availability unknown)."
+  if [[ -n "$KC_VERSION_RAW" ]] && [[ "$KC_VERSION_RAW" == *"SNAPSHOT"* ]]; then
+    warn "SNAPSHOT build ($KC_VERSION_RAW); skipping credential grants (feature availability unknown)."
   elif [[ -z "$KC_MAJOR_MINOR" ]]; then
-    warn "Could not determine Keycloak version from '${KEYCLOAK_VERSION:-unknown}'; skipping credential grants."
+    warn "Could not determine Keycloak server version; skipping credential grants."
   else
-    warn "Keycloak $KEYCLOAK_VERSION < 26.7; skipping credential grants."
+    warn "Keycloak $KC_VERSION_RAW < 26.7; skipping credential grants."
   fi
 fi
 


### PR DESCRIPTION
This PR adds automatic verifiable credential grants for Keycloak 26.7+.

Credential scopes are configured in `config.yaml` and granted to the user when the configuration command is executed.

## Changes

* Added `credential_scopes` under `users.francis`
* Added credential grant logic for Keycloak 26.7+
* Reads scopes from `config.yaml` and `config.override.yaml`
* Skips the grant step for older Keycloak and snapshot versions
* Handles already granted scopes to allow the configuration to be run again safely
* Updated the migration documentation

## Configuration

```yaml
users:
  francis:
    credential_scopes:
      - "IdentityCredential"
      - "SteuerberaterCredential"
      - "KMACredential"
```

## Testing

### Keycloak 26.7.3

Tested the configuration with Keycloak `26.7.3`.

<img width="696" height="307" alt="Screenshot from 2026-09-02 11-34-01" src="https://github.com/user-attachments/assets/437ccd22-f755-412f-bb06-28c08b018c51" />

### Idempotency

Ran the configuration again after the credential scopes were already granted.

<img width="696" height="307" alt="Screenshot from 2026-09-02 11-34-11" src="https://github.com/user-attachments/assets/ea0d8f25-ad2f-4e06-b00a-de90be8400b8" />

### Older Keycloak version

Tested with Keycloak `26.6.0` to verify that the credential grant step is skipped.

<img width="710" height="100" alt="Screenshot from 2026-09-02 11-38-38" src="https://github.com/user-attachments/assets/16204830-0b7f-4f9a-9e4c-49848e0395c9" />

Closes #1055 